### PR TITLE
#153: Migrate to react native 0.62

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,14 +5,6 @@
 ; Ignore "BUCK" generated dirs
 <PROJECT_ROOT>/\.buckd/
 
-; Ignore unexpected extra "@providesModule"
-.*/node_modules/.*/node_modules/fbjs/.*
-
-; Ignore duplicate module providers
-; For RN Apps installed via npm, "Libraries" folder is inside
-; "node_modules/react-native" but in the source repo it is in the root
-node_modules/react-native/Libraries/react-native/React.js
-
 ; Ignore polyfills
 node_modules/react-native/Libraries/polyfills/.*
 
@@ -21,7 +13,7 @@ node_modules/react-native/Libraries/polyfills/.*
 node_modules/warning/.*
 
 ; Flow doesn't support platforms
-.*/Libraries/Utilities/HMRLoadingView.js
+.*/Libraries/Utilities/LoadingView.js
 
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
@@ -29,7 +21,7 @@ node_modules/warning/.*
 [include]
 
 [libs]
-node_modules/react-native/Libraries/react-native/react-native-interface.js
+node_modules/react-native/interface.js
 node_modules/react-native/flow/
 
 [options]
@@ -42,27 +34,10 @@ module.file_ext=.js
 module.file_ext=.json
 module.file_ext=.ios.js
 
-module.system=haste
-module.system.haste.use_name_reducers=true
-# get basename
-module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
-# strip .js or .js.flow suffix
-module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
-# strip .ios suffix
-module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
-module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
-module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
-module.system.haste.paths.blacklist=.*/__tests__/.*
-module.system.haste.paths.blacklist=.*/__mocks__/.*
-module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/Libraries/.*
-module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/RNTester/.*
-module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/IntegrationTests/.*
-module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/react-native/react-native-implementation.js
-module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/Animated/src/polyfills/.*
-
 munge_underscores=true
 
-module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
+module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/node_modules/react-native/\1'
+module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> '<PROJECT_ROOT>/node_modules/react-native/Libraries/Image/RelativeImageStub'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
@@ -96,4 +71,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.98.0
+^0.113.0

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pbxproj -text
+*.bat text eol=crlf

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -88,8 +88,19 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    
     if (enableHermes) {
       def hermesPath = "../../node_modules/hermesvm/android/";
       debugImplementation files(hermesPath + "hermes-debug.aar")

--- a/android/app/src/debug/java/com/platforme/ripe_components_react_native_storybook/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/platforme/ripe_components_react_native_storybook/ReactNativeFlipper.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
+ */
+package com.platforme.ripe_components_react_native_storybook;
+
+import android.content.Context;
+import com.facebook.flipper.android.AndroidFlipperClient;
+import com.facebook.flipper.android.utils.FlipperUtils;
+import com.facebook.flipper.core.FlipperClient;
+import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin;
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin;
+import com.facebook.flipper.plugins.fresco.FrescoFlipperPlugin;
+import com.facebook.flipper.plugins.inspector.DescriptorMapping;
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
+import com.facebook.flipper.plugins.react.ReactFlipperPlugin;
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.modules.network.NetworkingModule;
+import okhttp3.OkHttpClient;
+
+public class ReactNativeFlipper {
+  public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+    if (FlipperUtils.shouldEnableFlipper(context)) {
+      final FlipperClient client = AndroidFlipperClient.getInstance(context);
+
+      client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
+      client.addPlugin(new ReactFlipperPlugin());
+      client.addPlugin(new DatabasesFlipperPlugin(context));
+      client.addPlugin(new SharedPreferencesFlipperPlugin(context));
+      client.addPlugin(CrashReporterPlugin.getInstance());
+
+      NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
+      NetworkingModule.setCustomClientBuilder(
+          new NetworkingModule.CustomClientBuilder() {
+            @Override
+            public void apply(OkHttpClient.Builder builder) {
+              builder.addNetworkInterceptor(new FlipperOkhttpInterceptor(networkFlipperPlugin));
+            }
+          });
+      client.addPlugin(networkFlipperPlugin);
+      client.start();
+
+      // Fresco Plugin needs to ensure that ImagePipelineFactory is initialized
+      // Hence we run if after all native modules have been initialized
+      ReactContext reactContext = reactInstanceManager.getCurrentReactContext();
+      if (reactContext == null) {
+        reactInstanceManager.addReactInstanceEventListener(
+            new ReactInstanceManager.ReactInstanceEventListener() {
+              @Override
+              public void onReactContextInitialized(ReactContext reactContext) {
+                reactInstanceManager.removeReactInstanceEventListener(this);
+                reactContext.runOnNativeModulesQueueThread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        client.addPlugin(new FrescoFlipperPlugin());
+                      }
+                    });
+              }
+            });
+      } else {
+        client.addPlugin(new FrescoFlipperPlugin());
+      }
+    }
+  }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,11 +15,12 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+      <!-- android:launchMode="singleTop" change in update react native 0.61.5 to 0.62.2 -->
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:launchMode="singleTop"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:launchMode="singleTask"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/java/com/platforme/ripe_components_react_native_storybook/MainApplication.java
+++ b/android/app/src/main/java/com/platforme/ripe_components_react_native_storybook/MainApplication.java
@@ -1,14 +1,14 @@
 package com.platforme.ripe_components_react_native_storybook;
 
 import android.app.Application;
-
+import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
-
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
@@ -37,41 +37,41 @@ public class MainApplication extends Application implements ReactApplication {
         return mReactNativeHost;
     }
 
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        SoLoader.init(this, false);
-        initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-    }
-     /**
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, false);
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
    * Loads Flipper in React Native templates. Call this in the onCreate method with something like
    * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
    *
    * @param context
    * @param reactInstanceManager
    */
-    private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
-        if (BuildConfig.DEBUG) {
-            try {
-                /*
-                We use reflection here to pick up the class that initializes Flipper,
-                since Flipper library is not available in release mode
-                */
-                Class<?> aClass = Class.forName("com.platforme.ripe_components_react_native_storybook.ReactNativeFlipper");
-                aClass
-                    .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
-                    .invoke(null, context, reactInstanceManager);
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            } catch (NoSuchMethodException e) {
-                e.printStackTrace();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            } catch (InvocationTargetException e) {
-                e.printStackTrace();
-            }
-        }
+  private static void initializeFlipper(
+      Context context, ReactInstanceManager reactInstanceManager) {
+    if (BuildConfig.DEBUG) {
+      try {
+        /*
+         We use reflection here to pick up the class that initializes Flipper,
+        since Flipper library is not available in release mode
+        */
+        Class<?> aClass = Class.forName("com.platforme.ripe_components_react_native_storybook.ReactNativeFlipper");
+        aClass
+            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+            .invoke(null, context, reactInstanceManager);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      } catch (NoSuchMethodException e) {
+        e.printStackTrace();
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
     }
-
-    
+  }
 }

--- a/android/app/src/main/java/com/platforme/ripe_components_react_native_storybook/MainApplication.java
+++ b/android/app/src/main/java/com/platforme/ripe_components_react_native_storybook/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
@@ -40,5 +41,37 @@ public class MainApplication extends Application implements ReactApplication {
     public void onCreate() {
         super.onCreate();
         SoLoader.init(this, false);
+        initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
     }
+     /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+    private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+        if (BuildConfig.DEBUG) {
+            try {
+                /*
+                We use reflection here to pick up the class that initializes Flipper,
+                since Flipper library is not available in release mode
+                */
+                Class<?> aClass = Class.forName("com.platforme.ripe_components_react_native_storybook.ReactNativeFlipper");
+                aClass
+                    .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+                    .invoke(null, context, reactInstanceManager);
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,5 +27,6 @@ allprojects {
 
         google()
         jcenter()
+        maven { url 'https://www.jitpack.io' }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,5 @@
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.parallel=true
+# Version of flipper SDK to use with React Native
+FLIPPER_VERSION=0.33.1

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/gradlew
+++ b/android/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,6 +1,47 @@
 platform :ios, '9.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
+def add_flipper_pods!(versions = {})
+  versions['Flipper'] ||= '~> 0.33.1'
+  versions['DoubleConversion'] ||= '1.1.7'
+  versions['Flipper-Folly'] ||= '~> 2.1'
+  versions['Flipper-Glog'] ||= '0.3.6'
+  versions['Flipper-PeerTalk'] ||= '~> 0.0.4'
+  versions['Flipper-RSocket'] ||= '~> 1.0'
+  pod 'FlipperKit', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutPlugin', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/SKIOSNetworkPlugin', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitReactPlugin', versions['Flipper'], :configuration => 'Debug'
+  # List all transitive dependencies for FlipperKit pods
+  # to avoid them being linked in Release builds
+  pod 'Flipper', versions['Flipper'], :configuration => 'Debug'
+  pod 'Flipper-DoubleConversion', versions['DoubleConversion'], :configuration => 'Debug'
+  pod 'Flipper-Folly', versions['Flipper-Folly'], :configuration => 'Debug'
+  pod 'Flipper-Glog', versions['Flipper-Glog'], :configuration => 'Debug'
+  pod 'Flipper-PeerTalk', versions['Flipper-PeerTalk'], :configuration => 'Debug'
+  pod 'Flipper-RSocket', versions['Flipper-RSocket'], :configuration => 'Debug'
+  pod 'FlipperKit/Core', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/CppBridge', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FBCxxFollyDynamicConvert', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FBDefines', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FKPortForwarding', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitHighlightOverlay', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutTextSearchable', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitNetworkPlugin', versions['Flipper'], :configuration => 'Debug'
+end
+# Post Install processing for Flipper
+def flipper_post_install(installer)
+  installer.pods_project.targets.each do |target|
+    if target.name == 'YogaKit'
+      target.build_configurations.each do |config|
+        config.build_settings['SWIFT_VERSION'] = '4.1'
+      end
+    end
+  end
+end
+
+
 target 'ripeComponentsReactNativeStorybook' do
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
@@ -25,17 +66,26 @@ target 'ripeComponentsReactNativeStorybook' do
   pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
   pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
   pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/jscallinvoker', :path => "../node_modules/react-native/ReactCommon"
+  pod 'ReactCommon/callinvoker', :path => "../node_modules/react-native/ReactCommon"
   pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   target 'ripeComponentsReactNativeStorybookTests' do
-    inherit! :search_paths
+    inherit! :complete
   end
 
   use_native_modules!
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable these next few lines.
+  add_flipper_pods!
+  post_install do |installer|
+    flipper_post_install(installer)
+  end
+
 end

--- a/ios/ripe-components-react-native-storybook.xcodeproj/project.pbxproj
+++ b/ios/ripe-components-react-native-storybook.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		778DA82106C5561FD67A2B5E /* libPods-ripeComponentsReactNativeStorybookTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 091504F64F02DD6A55E225D5 /* libPods-ripeComponentsReactNativeStorybookTests.a */; };
+		8265B0054F1DEFEDF635E0D6 /* libPods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BB7215CDBB4D9CE9793FBE0 /* libPods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.a */; };
 		C2D5260323EB5ECC00DFAE14 /* Soleil-Bold-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C238F75423EB59EE00B8FF2D /* Soleil-Bold-Italic.ttf */; };
 		C2D5260423EB5ECC00DFAE14 /* Soleil-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C238F75523EB59EE00B8FF2D /* Soleil-Bold.ttf */; };
 		C2D5260523EB5ECC00DFAE14 /* Soleil-Book.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C238F75623EB59EE00B8FF2D /* Soleil-Book.ttf */; };
@@ -37,7 +37,7 @@
 		00E356EE1AD99517003FC87E /* ripeComponentsReactNativeStorybookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ripeComponentsReactNativeStorybookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* ripeComponentsReactNativeStorybookTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ripeComponentsReactNativeStorybookTests.m; sourceTree = "<group>"; };
-		091504F64F02DD6A55E225D5 /* libPods-ripeComponentsReactNativeStorybookTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ripeComponentsReactNativeStorybookTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0816BD0D403A3AD3D29E08D1 /* Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.release.xcconfig"; path = "Target Support Files/Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests/Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.release.xcconfig"; sourceTree = "<group>"; };
 		0E2522F605E300D36A32A019 /* Pods-ripe-components-react-native-storybook.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripe-components-react-native-storybook.release.xcconfig"; path = "Target Support Files/Pods-ripe-components-react-native-storybook/Pods-ripe-components-react-native-storybook.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* ripe-components-react-native-storybook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ripe-components-react-native-storybook.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = "ripe-components-react-native-storybook/AppDelegate.h"; sourceTree = "<group>"; };
@@ -48,6 +48,8 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "ripe-components-react-native-storybook/main.m"; sourceTree = "<group>"; };
 		13E10C7B35775C5825CB0AE1 /* Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig"; path = "Target Support Files/Pods-ripeComponentsReactNativeStorybookTests/Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1492453DAD410F095AB422CA /* Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig"; path = "Target Support Files/Pods-ripeComponentsReactNativeStorybookTests/Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig"; sourceTree = "<group>"; };
+		224032F61BE54783F256B7A7 /* Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.debug.xcconfig"; path = "Target Support Files/Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests/Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4BB7215CDBB4D9CE9793FBE0 /* libPods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7939965EF52E66ECA48B6973 /* Pods-ripeComponentsReactNativeStorybookTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripeComponentsReactNativeStorybookTests.release.xcconfig"; path = "Target Support Files/Pods-ripeComponentsReactNativeStorybookTests/Pods-ripeComponentsReactNativeStorybookTests.release.xcconfig"; sourceTree = "<group>"; };
 		8F8D03A69ECF0BD10F4F8C8A /* Pods-ripe-components-react-native-storybook.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripe-components-react-native-storybook.debug.xcconfig"; path = "Target Support Files/Pods-ripe-components-react-native-storybook/Pods-ripe-components-react-native-storybook.debug.xcconfig"; sourceTree = "<group>"; };
 		92C564B30EBA5D18E8666C07 /* Pods-ripe-components-react-native-storybook-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ripe-components-react-native-storybook-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-ripe-components-react-native-storybook-tvOSTests/Pods-ripe-components-react-native-storybook-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -74,7 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				778DA82106C5561FD67A2B5E /* libPods-ripeComponentsReactNativeStorybookTests.a in Frameworks */,
+				8265B0054F1DEFEDF635E0D6 /* libPods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,8 +129,8 @@
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
 				E2374381C88171FFE393E58C /* libPods-ripe-components-react-native-storybook-tvOS.a */,
 				9F12E115C363B3A84E12556A /* libPods-ripe-components-react-native-storybook-tvOSTests.a */,
-				091504F64F02DD6A55E225D5 /* libPods-ripeComponentsReactNativeStorybookTests.a */,
 				DE58993AB8D493FEB8EB5618 /* libPods-ripeComponentsReactNativeStorybook.a */,
+				4BB7215CDBB4D9CE9793FBE0 /* libPods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -160,6 +162,8 @@
 				AF6A7868984B5A72CAE88F2D /* Pods-ripeComponentsReactNativeStorybook.release.xcconfig */,
 				13E10C7B35775C5825CB0AE1 /* Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig */,
 				7939965EF52E66ECA48B6973 /* Pods-ripeComponentsReactNativeStorybookTests.release.xcconfig */,
+				224032F61BE54783F256B7A7 /* Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.debug.xcconfig */,
+				0816BD0D403A3AD3D29E08D1 /* Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -311,7 +315,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		20B3010CCFEF011B1B2E2034 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -328,7 +332,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ripeComponentsReactNativeStorybookTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -421,7 +425,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 13E10C7B35775C5825CB0AE1 /* Pods-ripeComponentsReactNativeStorybookTests.debug.xcconfig */;
+			baseConfigurationReference = 224032F61BE54783F256B7A7 /* Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -444,7 +448,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7939965EF52E66ECA48B6973 /* Pods-ripeComponentsReactNativeStorybookTests.release.xcconfig */;
+			baseConfigurationReference = 0816BD0D403A3AD3D29E08D1 /* Pods-ripeComponentsReactNativeStorybook-ripeComponentsReactNativeStorybookTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -468,7 +472,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = NO;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"FB_SONARKIT_ENABLED=1",
+				);
 				INFOPLIST_FILE = "ripe-components-react-native-storybook/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -549,6 +559,12 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -596,6 +612,12 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/ios/ripe-components-react-native-storybook.xcodeproj/xcshareddata/xcschemes/ripe-components-react-native-storybook.xcscheme
+++ b/ios/ripe-components-react-native-storybook.xcodeproj/xcshareddata/xcschemes/ripe-components-react-native-storybook.xcscheme
@@ -3,23 +3,9 @@
    LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "83CBBA2D1A601D0E00E9B192"
-               BuildableName = "libReact.a"
-               BlueprintName = "React"
-               ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -34,20 +20,6 @@
                ReferencedContainer = "container:ripe-components-react-native-storybook.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
-               BuildableName = "ripeComponentsReactNativeStorybookTests.xctest"
-               BlueprintName = "ripeComponentsReactNativeStorybookTests"
-               ReferencedContainer = "container:ripe-components-react-native-storybook.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "ripe-components-react-native-storybook.app"
-            BlueprintName = "ripeComponentsReactNativeStorybook"
-            ReferencedContainer = "container:ripe-components-react-native-storybook.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ios/ripe-components-react-native-storybook/AppDelegate.m
+++ b/ios/ripe-components-react-native-storybook/AppDelegate.m
@@ -4,9 +4,32 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 
+#if DEBUG
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    #if DEBUG
+        InitializeFlipper(application);
+    #endif
+
     RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                      moduleName:@"ripe-components-react-native-storybook"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@react-native-community/async-storage": "^1.9.0",
         "@react-native-community/masked-view": "^0.1.7",
         "react": "^16.13.1",
-        "react-native": "^0.61.5",
+        "react-native": "^0.62.2",
         "react-native-document-picker": "^3.3.3",
         "react-native-image-picker": "^2.3.1",
         "react-native-linear-gradient": "^2.5.6",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | related to this one, https://github.com/ripe-tech/ripe-robin-revamp/issues/153 |
| Dependencies | - |
| Decisions | In this update we had some problems in the iOS platform, almost all of them where because of the default support of flipper, a debug tool for react-native.<br>This tool introduced some mandatory configurations for swift files, configurations that we didn’t had. <br>So we end up changing a few things:<br>He had to verify and change stuff in the search code path and in dead code striping,  verify and fix swift files search path  and some other stuff. Because of this changes in the configuration of the project is mandatory that we test this in debug and in release, there is a high chance of stuff working in debug and crashing in release . The place with higher chance of crashing is in the build process, nevertheless a quick look in the app while running should be enough to guarantee any possible crashes on that part!|
| Animated GIF | - |