### PR TITLE
fix: set NDK to match the runner's

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
-        ndkVersion = "21.3.6528147"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()


### PR DESCRIPTION
Backport from https://github.com/ripe-tech/ripe-robin-revamp/pull/211