### PR TITLE
fix: add missing step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ The storybook for the [RIPE Components for React Native](https://github.com/ripe
 npm run wml-link-components
 npm run wml
 npm run storybook
+npm run clear
 npm run android # or ios
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ The storybook for the [RIPE Components for React Native](https://github.com/ripe
 npm run wml-link-components
 npm run wml
 npm run storybook
-npm run clear
+npm run start
 npm run android # or ios
 ```


### PR DESCRIPTION
`npm run clear` will start react native metro bundler.

Not starting react native will give this error:

<img width="413" alt="wesdrfthjkl" src="https://user-images.githubusercontent.com/8842023/121863369-b0c8c900-ccf3-11eb-8896-d0c0d33e50f7.png">
